### PR TITLE
Reduce User Action Needed event spam

### DIFF
--- a/octoprint_webhooks/__init__.py
+++ b/octoprint_webhooks/__init__.py
@@ -6,6 +6,9 @@ import requests
 import time
 import sys
 
+from datetime import datetime
+from datetime import timedelta
+
 from io import BytesIO
 from PIL import Image
 
@@ -135,6 +138,7 @@ class WebhooksPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplatePl
 					 octoprint.plugin.EventHandlerPlugin, octoprint.plugin.AssetPlugin, octoprint.plugin.SimpleApiPlugin,
 					 octoprint.plugin.ProgressPlugin):
 	def __init__(self):
+		self.last_user_action_notification = datetime.now() - timedelta(seconds=60)
 		self.triggered = False
 		self.last_print_progress = -1
 		self.last_print_progress_milestones = []
@@ -569,8 +573,12 @@ class WebhooksPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplatePl
 		# Found keyword, fire event and block until other text is received
 		if "echo:busy: paused for user" in line:
 			if not self.triggered:
-				eventManager().fire(Events.PLUGIN_WEBHOOKS_NOTIFY)
 				self.triggered = True
+
+				if timedelta.total_seconds(datetime.now() - self.last_user_action_notification) > 60:
+					eventManager().fire(Events.PLUGIN_WEBHOOKS_NOTIFY)
+					self.last_user_action_notification = datetime.now()
+					
 		# Other text, we may fire another event if we encounter "paused for user" again
 		else:
 			self.triggered = False

--- a/octoprint_webhooks/__init__.py
+++ b/octoprint_webhooks/__init__.py
@@ -6,8 +6,7 @@ import requests
 import time
 import sys
 
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from io import BytesIO
 from PIL import Image
@@ -578,7 +577,7 @@ class WebhooksPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.TemplatePl
 				if timedelta.total_seconds(datetime.now() - self.last_user_action_notification) > 60:
 					eventManager().fire(Events.PLUGIN_WEBHOOKS_NOTIFY)
 					self.last_user_action_notification = datetime.now()
-					
+
 		# Other text, we may fire another event if we encounter "paused for user" again
 		else:
 			self.triggered = False


### PR DESCRIPTION
Simple change to make User Action Needed event fire once per minute.

Without this change, I would get rate-limited in Discord because 40 or 50 notifications were sent before I could get upstairs and swap filament.  It was even worse if I didn't notice the notification right away, a whole channel with nothing but 'User action needed' messages, drowning out all else.